### PR TITLE
domain knoledge was included in application service.

### DIFF
--- a/src/main/kotlin/application/BalanceService.kt
+++ b/src/main/kotlin/application/BalanceService.kt
@@ -10,9 +10,9 @@ class BalanceService {
     val repository: AccountRepository = AccountRepositoryImpl()
     val cashing = Cashing()
 
-    fun doBilling(accountNumber: String, money: Money) {
+    fun doBilling(accountNumber: String, money: Int) {
         val account = repository.findByAccountNo(accountNumber)
-        val cashed = cashing.chargeTo(account, money)
+        val cashed = cashing.chargeTo(account, Money(money))
         repository.save(cashed)
 
     }

--- a/src/main/kotlin/domain/model/shop/PurchaseStartSubscriber.kt
+++ b/src/main/kotlin/domain/model/shop/PurchaseStartSubscriber.kt
@@ -16,7 +16,7 @@ class PurchaseStartSubscriber : DomainEventSubscriber {
                 .balanceService()
                 .doBilling(
                         billingEvent.identities.accountNumber,
-                        billingEvent.money)
+                        billingEvent.money.value)
     }
 
     override fun subScribedToEventType(): Class<*> {


### PR DESCRIPTION
アプリケーションサービスの入り口では変換前のドメインの情報があるべき。
いきなりドメインの情報を引数としてもらっちゃうと、責務がよくわからなくなる。